### PR TITLE
Update references to pose_graph_tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(dpgo_ros)
 SET(CMAKE_BUILD_TYPE Debug)
 
 find_package(DPGO REQUIRED)
+find_package(pose_graph_tools REQUIRED)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++17 -march=native -pthread -O3")
@@ -19,7 +20,8 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   visualization_msgs
   message_generation
-  pose_graph_tools
+  pose_graph_tools_msgs
+  pose_graph_tools_ros
 )
 
 
@@ -85,7 +87,7 @@ add_service_files(
    DEPENDENCIES
    std_msgs
    geometry_msgs
-   pose_graph_tools
+   pose_graph_tools_msgs
  )
 
 ################################################
@@ -148,8 +150,10 @@ add_library(${PROJECT_NAME}
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(${PROJECT_NAME}
-  ${catkin_LIBRARIES}
-  DPGO
+  PUBLIC
+    ${catkin_LIBRARIES}
+    DPGO
+    pose_graph_tools::pose_graph_tools
 )
 
 # Declare a C++ executable

--- a/include/dpgo_ros/PGOAgentROS.h
+++ b/include/dpgo_ros/PGOAgentROS.h
@@ -15,7 +15,7 @@
 #include <dpgo_ros/RelativeMeasurementWeights.h>
 #include <dpgo_ros/QueryLiftingMatrix.h>
 #include <dpgo_ros/Status.h>
-#include <pose_graph_tools/PoseGraph.h>
+#include <pose_graph_tools/pose_graph.h>
 #include <visualization_msgs/Marker.h>
 #include <std_msgs/UInt16MultiArray.h>
 #include <ros/console.h>

--- a/include/dpgo_ros/utils.h
+++ b/include/dpgo_ros/utils.h
@@ -17,7 +17,8 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <sensor_msgs/PointCloud.h>
 #include <nav_msgs/Path.h>
-#include <pose_graph_tools/PoseGraph.h>
+#include <pose_graph_tools_msgs/PoseGraph.h>
+#include <pose_graph_tools_msgs/PoseGraphEdge.h>
 #include <tf/tf.h>
 
 #include <cassert>
@@ -25,7 +26,7 @@
 #include <vector>
 
 using namespace DPGO;
-using pose_graph_tools::PoseGraphEdge;
+using pose_graph_tools_msgs::PoseGraphEdge;
 
 namespace dpgo_ros {
 
@@ -117,7 +118,7 @@ sensor_msgs::PointCloud TrajectoryToPointCloud(unsigned d, unsigned n, const Mat
  * @param T
  * @return
  */
-pose_graph_tools::PoseGraph TrajectoryToPoseGraphMsg(unsigned robotID, unsigned d, unsigned n, const Matrix &T);
+pose_graph_tools_msgs::PoseGraph TrajectoryToPoseGraphMsg(unsigned robotID, unsigned d, unsigned n, const Matrix &T);
 
 /**
 Compute the number of bytes of a PublicPoses message.

--- a/msg/RelativeMeasurementList.msg
+++ b/msg/RelativeMeasurementList.msg
@@ -1,4 +1,4 @@
 uint16 from_robot                          # ID of the publishing robot
 uint16 from_cluster                        # Cluster that the publishing robot belongs to 
 uint16 to_robot                            # ID of the receiving robot
-pose_graph_tools/PoseGraphEdge[] edges
+pose_graph_tools_msgs/PoseGraphEdge[] edges

--- a/src/PGOAgentROS.cpp
+++ b/src/PGOAgentROS.cpp
@@ -11,8 +11,8 @@
 #include <geometry_msgs/PoseArray.h>
 #include <nav_msgs/Path.h>
 #include <tf/tf.h>
-#include <pose_graph_tools/PoseGraphQuery.h>
-#include <pose_graph_tools/utils.h>
+#include <pose_graph_tools_msgs/PoseGraphQuery.h>
+#include <pose_graph_tools_ros/utils.h>
 #include <glog/logging.h>
 #include <map>
 #include <random>
@@ -78,7 +78,7 @@ PGOAgentROS::PGOAgentROS(const ros::NodeHandle &nh_, unsigned ID,
   mMeasurementWeightsPublisher = nh.advertise<RelativeMeasurementWeights>("measurement_weights", 20);
   mPoseArrayPublisher = nh.advertise<geometry_msgs::PoseArray>("trajectory", 1);
   mPathPublisher = nh.advertise<nav_msgs::Path>("path", 1);
-  mPoseGraphPublisher = nh.advertise<pose_graph_tools::PoseGraph>("optimized_pose_graph", 1);
+  mPoseGraphPublisher = nh.advertise<pose_graph_tools_msgs::PoseGraph>("optimized_pose_graph", 1);
   mLoopClosureMarkerPublisher = nh.advertise<visualization_msgs::Marker>("loop_closures", 1);
 
   // ROS timer
@@ -245,7 +245,7 @@ void PGOAgentROS::reset() {
 
 bool PGOAgentROS::requestPoseGraph() {
   // Query local pose graph
-  pose_graph_tools::PoseGraphQuery query;
+  pose_graph_tools_msgs::PoseGraphQuery query;
   query.request.robot_id = getID();
   std::string service_name = "/" + mRobotNames.at(getID()) +
       "/distributed_loop_closure/request_pose_graph";
@@ -258,7 +258,7 @@ bool PGOAgentROS::requestPoseGraph() {
     return false;
   }
 
-  pose_graph_tools::PoseGraph pose_graph = query.response.pose_graph;
+  pose_graph_tools_msgs::PoseGraph pose_graph = query.response.pose_graph;
   if (pose_graph.edges.size() <= 1) {
     ROS_WARN("Received empty pose graph.");
     return false;
@@ -285,7 +285,7 @@ bool PGOAgentROS::requestPoseGraph() {
   PoseArray initial_poses(dimension(), num_poses());
   if (!pose_graph.nodes.empty()) {
     // Filter nodes that do not belong to this robot
-    vector<pose_graph_tools::PoseGraphNode> nodes_filtered;
+    vector<pose_graph_tools_msgs::PoseGraphNode> nodes_filtered;
     for (const auto &node : pose_graph.nodes) {
       if ((unsigned) node.robot_id == getID()) nodes_filtered.push_back(node);
     }
@@ -637,7 +637,7 @@ void PGOAgentROS::publishTrajectory(const PoseArray &T) {
   mPathPublisher.publish(path);
 
   // Publish as optimized pose graph
-  pose_graph_tools::PoseGraph pose_graph = TrajectoryToPoseGraphMsg(getID(), T.d(), T.n(), T.getData());
+  pose_graph_tools_msgs::PoseGraph pose_graph = TrajectoryToPoseGraphMsg(getID(), T.d(), T.n(), T.getData());
   mPoseGraphPublisher.publish(pose_graph);
 }
 

--- a/src/PGODatasetPublisherNode.cpp
+++ b/src/PGODatasetPublisherNode.cpp
@@ -7,8 +7,8 @@
 
 #include <DPGO/DPGO_utils.h>
 #include <dpgo_ros/utils.h>
-#include <pose_graph_tools/PoseGraph.h>
-#include <pose_graph_tools/PoseGraphQuery.h>
+#include <pose_graph_tools_msgs/PoseGraph.h>
+#include <pose_graph_tools_msgs/PoseGraphQuery.h>
 #include <ros/console.h>
 #include <ros/ros.h>
 
@@ -56,12 +56,12 @@ class DatasetPublisher {
  private:
   ros::NodeHandle nh;
   int num_robots;
-  vector<pose_graph_tools::PoseGraph> poseGraphs;
+  vector<pose_graph_tools_msgs::PoseGraph> poseGraphs;
   vector<ros::ServiceServer> poseGraphServers;
   std::map<unsigned, std::string> robotNames;
   bool queryPoseGraphCallback(
-      pose_graph_tools::PoseGraphQueryRequest &request,
-      pose_graph_tools::PoseGraphQueryResponse &response) {
+      pose_graph_tools_msgs::PoseGraphQueryRequest &request,
+      pose_graph_tools_msgs::PoseGraphQueryResponse &response) {
     if (request.robot_id >= poseGraphs.size()) {
       ROS_ERROR("DatasetPublisher: requested robot does not exist!");
       return false;
@@ -135,22 +135,22 @@ class DatasetPublisher {
     }
 
     for (size_t robot = 0; robot < (unsigned) num_robots; ++robot) {
-      pose_graph_tools::PoseGraph pose_graph;
+      pose_graph_tools_msgs::PoseGraph pose_graph;
       // Add odometry factors
       for (size_t k = 0; k < odometry[robot].size(); ++k) {
-        pose_graph_tools::PoseGraphEdge edge =
+        pose_graph_tools_msgs::PoseGraphEdge edge =
             dpgo_ros::RelativeMeasurementToMsg(odometry[robot][k]);
         pose_graph.edges.push_back(edge);
       }
       // Add private loop closures
       for (size_t k = 0; k < private_loop_closures[robot].size(); ++k) {
-        pose_graph_tools::PoseGraphEdge edge =
+        pose_graph_tools_msgs::PoseGraphEdge edge =
             dpgo_ros::RelativeMeasurementToMsg(private_loop_closures[robot][k]);
         pose_graph.edges.push_back(edge);
       }
       // Add shared loop closures
       for (size_t k = 0; k < shared_loop_closure[robot].size(); ++k) {
-        pose_graph_tools::PoseGraphEdge edge =
+        pose_graph_tools_msgs::PoseGraphEdge edge =
             dpgo_ros::RelativeMeasurementToMsg(shared_loop_closure[robot][k]);
         pose_graph.edges.push_back(edge);
       }
@@ -160,7 +160,7 @@ class DatasetPublisher {
 
   void loadFromMeasurements() {
     for (size_t robot_id = 0; robot_id < (unsigned) num_robots; ++robot_id) {
-      pose_graph_tools::PoseGraph pose_graph;
+      pose_graph_tools_msgs::PoseGraph pose_graph;
       std::string measurement_file;
       if (!ros::param::get("~robot" + std::to_string(robot_id) + "_measurements", measurement_file)) {
         ROS_ERROR("No measurement file specified for robot %zu!", robot_id);
@@ -168,7 +168,7 @@ class DatasetPublisher {
       std::vector<RelativeSEMeasurement> measurements = PGOLogger::loadMeasurements(measurement_file,
                                                                                     false);
       for (const auto &m : measurements) {
-        pose_graph_tools::PoseGraphEdge edge =
+        pose_graph_tools_msgs::PoseGraphEdge edge =
             dpgo_ros::RelativeMeasurementToMsg(m);
         pose_graph.edges.push_back(edge);
       }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -13,7 +13,7 @@
 #include <map>
 
 using namespace DPGO;
-using pose_graph_tools::PoseGraphEdge;
+using pose_graph_tools_msgs::PoseGraphEdge;
 
 namespace dpgo_ros {
 
@@ -220,15 +220,15 @@ sensor_msgs::PointCloud TrajectoryToPointCloud(unsigned d, unsigned n, const Mat
   return msg;
 }
 
-pose_graph_tools::PoseGraph TrajectoryToPoseGraphMsg(unsigned robotID, unsigned d, unsigned n, const Matrix &T) {
+pose_graph_tools_msgs::PoseGraph TrajectoryToPoseGraphMsg(unsigned robotID, unsigned d, unsigned n, const Matrix &T) {
   assert(d == 3);
   assert(T.rows() == d);
   assert(T.cols() == (d + 1) * n);
-  pose_graph_tools::PoseGraph pose_graph_msg;
+  pose_graph_tools_msgs::PoseGraph pose_graph_msg;
   pose_graph_msg.header.frame_id = "/world";
   pose_graph_msg.header.stamp = ros::Time::now();
   for (size_t i = 0; i < n; ++i) {
-    pose_graph_tools::PoseGraphNode node_msg;
+    pose_graph_tools_msgs::PoseGraphNode node_msg;
     node_msg.robot_id = robotID;
     node_msg.key = i;
     node_msg.header.frame_id = "/world";


### PR DESCRIPTION
The [pose_graph_tools](https://github.com/MIT-SPARK/pose_graph_tools) package has been split into two catkin packages (`_msgs` and `_ros`) and an underlying pure CMake package. These are the corresponding updates required to have dpgo_ros work with the latest version of pose_graph_tools. I tested these changes by building dpgo_ros and its dependencies in a clean catkin workspace and running all of the examples listed in the `README`.